### PR TITLE
bensampo/laravel-enum 6.0 has been released

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "bensampo/laravel-enum": "^3.1|^4.0|^5.0",
+        "bensampo/laravel-enum": "^3.1|^4.0|^5.0|^6.0",
         "illuminate/support": "^8.0|^9.0",
         "laravel/nova": "^3.0|^4.0"
     },


### PR DESCRIPTION
This MR allows the installation together with bensampo/laravel-enum:^6. bensampo/laravel-enum:6.0.0 has only one breaking chance which will not affect simplesquid/nova-enum-field
See for details: https://github.com/BenSampo/laravel-enum/blob/master/CHANGELOG.md